### PR TITLE
fix: Use custom font with buttons

### DIFF
--- a/axe-devtools-ios-sample-app/Cart/Views/CartCheckoutFooterView.swift
+++ b/axe-devtools-ios-sample-app/Cart/Views/CartCheckoutFooterView.swift
@@ -32,15 +32,15 @@ class CartCheckoutFooterView: UIView {
     }()
 
     lazy var checkoutButton: UIButton = {
+        let b = UIButton(type: .custom)
+        let gilroyBold = UIFont(name: "Gilroy-ExtraBold", size: 14)
         var configuration = UIButton.Configuration.plain()
         configuration.image = UIImage(named: viewModel.imageName)
         configuration.imagePlacement = .trailing
-        let b = UIButton(configuration: configuration)
-        b.translatesAutoresizingMaskIntoConstraints = false
-        b.titleLabel?.textColor = .white
-        b.titleLabel?.font = UIFont(name: "Gilroy-ExtraBold", size: 14)
-        b.setTitle("Proceed to checkout ", for: .normal)
+        configuration.attributedTitle = AttributedString("Proceed to checkout ", attributes: AttributeContainer([NSAttributedString.Key.font : UIFont(name: "Gilroy-ExtraBold", size: 14)!]))
+        b.configuration = configuration
         b.tintColor = .white
+        b.translatesAutoresizingMaskIntoConstraints = false
         return b
     }()
 

--- a/axe-devtools-ios-sample-app/Home/Views/HomeScreenImage/HomeImageView.swift
+++ b/axe-devtools-ios-sample-app/Home/Views/HomeScreenImage/HomeImageView.swift
@@ -49,34 +49,18 @@ class HomeImageView: UIView {
         return label
     }()
 
-    // for some reason, this code still creates a button with the default font (keeping it like this for the purpose of SupportsDynamicType testing)
     lazy var checkButton: UIButton = {
+        let b = UIButton(type: .custom)
+        let gilroyBold = UIFont(name: "Gilroy-ExtraBold", size: 14)
         var configuration = UIButton.Configuration.plain()
         configuration.image = UIImage(named: viewModel.buttonImage)
         configuration.imagePlacement = .trailing
-        let b = UIButton(configuration: configuration)
-        b.setTitle(viewModel.buttonText, for: .normal)
-        b.titleLabel?.textColor = .white
+        configuration.attributedTitle = AttributedString(viewModel.buttonText, attributes: AttributeContainer([NSAttributedString.Key.font : UIFont(name: "Gilroy-ExtraBold", size: 14)!]))
+        b.configuration = configuration
         b.tintColor = .white
-        let gilroyBold = UIFont(name: "Gilroy-ExtraBold", size: 14)
-        b.titleLabel?.font = gilroyBold
         b.translatesAutoresizingMaskIntoConstraints = false
         return b
     }()
-
-//    // uncomment this one to use custom font
-//    lazy var checkButton: UIButton = {
-//        let b = UIButton(type: .custom)
-//        let gilroyBold = UIFont(name: "Gilroy-ExtraBold", size: 14)
-//        var configuration = UIButton.Configuration.plain()
-//        configuration.image = UIImage(named: viewModel.buttonImage)
-//        configuration.imagePlacement = .trailing
-//        configuration.attributedTitle = AttributedString(viewModel.buttonText, attributes: AttributeContainer([NSAttributedString.Key.font : UIFont(name: "Gilroy-ExtraBold", size: 14)!]))
-//        b.configuration = configuration
-//        b.tintColor = .white
-//        b.translatesAutoresizingMaskIntoConstraints = false
-//        return b
-//    }()
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/axe-devtools-ios-sample-app/Home/Views/HomeScreenImage/HomeImageView.swift
+++ b/axe-devtools-ios-sample-app/Home/Views/HomeScreenImage/HomeImageView.swift
@@ -49,6 +49,7 @@ class HomeImageView: UIView {
         return label
     }()
 
+    // for some reason, this code still creates a button with the default font (keeping it like this for the purpose of SupportsDynamicType testing)
     lazy var checkButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
         configuration.image = UIImage(named: viewModel.buttonImage)
@@ -62,6 +63,20 @@ class HomeImageView: UIView {
         b.translatesAutoresizingMaskIntoConstraints = false
         return b
     }()
+
+//    // uncomment this one to use custom font
+//    lazy var checkButton: UIButton = {
+//        let b = UIButton(type: .custom)
+//        let gilroyBold = UIFont(name: "Gilroy-ExtraBold", size: 14)
+//        var configuration = UIButton.Configuration.plain()
+//        configuration.image = UIImage(named: viewModel.buttonImage)
+//        configuration.imagePlacement = .trailing
+//        configuration.attributedTitle = AttributedString(viewModel.buttonText, attributes: AttributeContainer([NSAttributedString.Key.font : UIFont(name: "Gilroy-ExtraBold", size: 14)!]))
+//        b.configuration = configuration
+//        b.tintColor = .white
+//        b.translatesAutoresizingMaskIntoConstraints = false
+//        return b
+//    }()
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/axe-devtools-ios-sample-app/Home/Views/MostPopularItems/MostPopularItemsHeaderView.swift
+++ b/axe-devtools-ios-sample-app/Home/Views/MostPopularItems/MostPopularItemsHeaderView.swift
@@ -20,17 +20,16 @@ class MostPopularItemsHeaderView: UICollectionReusableView {
     }()
 
     lazy var itemsButton: UIButton = {
+        let b = UIButton(type: .custom)
+        let gilroyBold = UIFont(name: "Gilroy-ExtraBold", size: 14)
         var configuration = UIButton.Configuration.plain()
         configuration.image = UIImage(named: "ArrowGray")
         configuration.imagePlacement = .trailing
-        let l = UIButton(configuration: configuration)
-        l.translatesAutoresizingMaskIntoConstraints = false
-        l.titleLabel?.textColor = .lightGray
-        l.titleLabel?.tintColor = .lightGray
-        let gilroyBold = UIFont(name: "Gilroy-ExtraBold", size: 14)
-        l.titleLabel?.font = gilroyBold
-        l.setTitle("56 Items ", for: .normal)
-        return l
+        configuration.attributedTitle = AttributedString("56 Items ", attributes: AttributeContainer([NSAttributedString.Key.font : UIFont(name: "Gilroy-ExtraBold", size: 14)!]))
+        b.configuration = configuration
+        b.tintColor = .lightGray
+        b.translatesAutoresizingMaskIntoConstraints = false
+        return b
     }()
 
     override init(frame: CGRect) {

--- a/axe-devtools-ios-sample-app/Home/Views/RecommendedItems/RecommendedItemsHeaderView.swift
+++ b/axe-devtools-ios-sample-app/Home/Views/RecommendedItems/RecommendedItemsHeaderView.swift
@@ -20,17 +20,16 @@ class RecommendedItemsHeaderView: UICollectionReusableView {
     }()
 
     lazy var itemsButton: UIButton = {
+        let b = UIButton(type: .custom)
+        let gilroyBold = UIFont(name: "Gilroy-ExtraBold", size: 14)
         var configuration = UIButton.Configuration.plain()
         configuration.image = UIImage(named: "ArrowGray")
         configuration.imagePlacement = .trailing
-        let l = UIButton(configuration: configuration)
-        l.translatesAutoresizingMaskIntoConstraints = false
-        l.titleLabel?.textColor = .lightGray
-        l.titleLabel?.tintColor = .lightGray
-        let gilroyBold = UIFont(name: "Gilroy-ExtraBold", size: 14)
-        l.titleLabel?.font = gilroyBold
-        l.setTitle("13 Items ", for: .normal)
-        return l
+        configuration.attributedTitle = AttributedString("13 Items ", attributes: AttributeContainer([NSAttributedString.Key.font : UIFont(name: "Gilroy-ExtraBold", size: 14)!]))
+        b.configuration = configuration
+        b.tintColor = .lightGray
+        b.translatesAutoresizingMaskIntoConstraints = false
+        return b
     }()
 
     override init(frame: CGRect) {


### PR DESCRIPTION
Some buttons were using the default Swift font instead of a custom font.