### PR TITLE
fix: add example touch target fix on home image

### DIFF
--- a/axe-devtools-ios-sample-app.xcodeproj/project.pbxproj
+++ b/axe-devtools-ios-sample-app.xcodeproj/project.pbxproj
@@ -367,14 +367,6 @@
 			path = RecommendedItems;
 			sourceTree = "<group>";
 		};
-		F3799ACF27F2088E009CFC2E /* HomeScreenImage */ = {
-			isa = PBXGroup;
-			children = (
-				F3A1A66E27E37B4F00E4F0E7 /* HomeImageView.swift */,
-			);
-			path = HomeScreenImage;
-			sourceTree = "<group>";
-		};
 		F3799AD027F208B3009CFC2E /* MostPopularItems */ = {
 			isa = PBXGroup;
 			children = (
@@ -487,6 +479,7 @@
 				F3F31D8E27DFD32500D87988 /* AppDelegate.swift */,
 				F3F31D9027DFD32500D87988 /* SceneDelegate.swift */,
 				6AEDD8512886FD4D0017DCF1 /* Login.swift */,
+				F3A1A66E27E37B4F00E4F0E7 /* HomeImageView.swift */,
 				F3A1A67027E37D0600E4F0E7 /* Shared */,
 				F3EFAC4027E1394D004A87C9 /* Home */,
 				F3A1A67927E3A4D100E4F0E7 /* Catalog */,
@@ -521,7 +514,6 @@
 			isa = PBXGroup;
 			children = (
 				F3EFAC2C27E10A58004A87C9 /* SearchBarView.swift */,
-				F3799ACF27F2088E009CFC2E /* HomeScreenImage */,
 				F3799AD027F208B3009CFC2E /* MostPopularItems */,
 				F3799ACD27F20866009CFC2E /* Collections  */,
 				F3799ACE27F20876009CFC2E /* RecommendedItems */,

--- a/axe-devtools-ios-sample-app/HomeImageView.swift
+++ b/axe-devtools-ios-sample-app/HomeImageView.swift
@@ -83,11 +83,11 @@ class HomeImageView: UIView {
     override func updateConstraints() {
         super.updateConstraints()
 
+        // Button is not automatically 44px high, so we'll add this constraint to fix the TouchTarget Failure
+        // checkButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 44).isActive = true
+
         NSLayoutConstraint.activate([
             imageView.topAnchor.constraint(equalTo: self.topAnchor),
-           // imageView.heightAnchor.constraint(equalToConstant: 327),
-           // imageView.widthAnchor.constraint(equalToConstant: 327),
-
             imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 24),
             imageView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -24),
             imageView.bottomAnchor.constraint(equalTo: self.bottomAnchor)

--- a/axe-devtools-ios-sample-app/Shared/MainTabBarViewController.swift
+++ b/axe-devtools-ios-sample-app/Shared/MainTabBarViewController.swift
@@ -32,7 +32,7 @@ class MainTabBarViewController: UITabBarController {
                                 image: UIImage(named: catalogVM.iconName)!,
                                 selectedImage: UIImage(named: catalogVM.selectedImage)!),
             createNavController(for: CartViewViewController(),
-                                title: "",
+                                title: "Cart",
                                 image: UIImage(named: cartVM.iconName)!,
                                 selectedImage: UIImage(named: cartVM.selectedImage)!),
             createNavController(for: ProfileViewController(),


### PR DESCRIPTION
- Move HomeScreenImage file to top of navigation
- Add constraint (commented out) to fix the touch target fail for home screen's check button. This was a failure from an out of the box button, in a stack view that didn't specify the minimum height requirement.

- Fix is to add the minimum height requirement on line 87.