### PR TITLE
feat: add scan names

### DIFF
--- a/RegressionUITests/RegressionUITests.swift
+++ b/RegressionUITests/RegressionUITests.swift
@@ -42,11 +42,12 @@ class RegressionUITests: XCTestCase {
     }
 
     // A helper method for keeping things cleaner when pushing to the dashboard, or saving a result locally.
-    func scanForAccessibility(withScanName: String = "unnamed scan") throws {
+    func scanForAccessibility(withScanName name: String = "unnamed scan") throws {
         guard let result = try axe?.run(onElement: app) else { XCTFail(); return }
         lastResult = result
-//        try axe?.postResult(result, withScanName: withScanName)
-        try axe?.saveResult(result, toPath: "RegressionScans", withScanName: withScanName)
+        // Post the report to the dashboard
+        // try axe?.postResult(result, withScanName: withScanName)
+        _ = try axe?.saveResult(result, toPath: "RegressionScans", withFileName: name, withScanName: name)
     }
 
     func assertNoCriticalResults() {

--- a/RegressionUITests/RegressionUITests.swift
+++ b/RegressionUITests/RegressionUITests.swift
@@ -23,29 +23,30 @@ class RegressionUITests: XCTestCase {
     // Iterates through each tab of the sample application and runs an accessibility scan on the screen, then posts it to the dashboard. Contains a few different options for implementing -- feel free to play around with it!
     func testHappyPathAccessibility() throws {
         // Run a scan on the first page and post the result to the dashboard.
-        try scanForAccessibility()
+        try scanForAccessibility(withScanName: "Home")
 
         //navigate to a tab by it's index, and run a scan, post to the dashboard
         let tabBar = XCUIApplication().tabBars["Tab Bar"]
         tabBar.children(matching: .button).element(boundBy: 1).tap()
-        try scanForAccessibility()
+        try scanForAccessibility(withScanName: "Catalog")
 
         // FOR DEMO: Fail the test if critical accessibility errors are found on the first page.
         assertNoCriticalResults()
 
         //navigate to a tab by its title
         tabBar.buttons["Cart"].tap()
-        try scanForAccessibility()
+        try scanForAccessibility(withScanName: "Cart")
 
         tabBar.children(matching: .button).element(boundBy: 3).tap()
-        try scanForAccessibility()
+        try scanForAccessibility(withScanName: "Profile")
     }
 
     // A helper method for keeping things cleaner when pushing to the dashboard, or saving a result locally.
-    func scanForAccessibility() throws {
+    func scanForAccessibility(withScanName: String = "unnamed scan") throws {
         guard let result = try axe?.run(onElement: app) else { XCTFail(); return }
         lastResult = result
-        try axe?.saveResult(result, toPath: "RegressionScans")
+//        try axe?.postResult(result, withScanName: withScanName)
+        try axe?.saveResult(result, toPath: "RegressionScans", withScanName: withScanName)
     }
 
     func assertNoCriticalResults() {

--- a/axe-devtools-ios-sample-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/axe-devtools-ios-sample-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/dequelabs/axe-devtools-ios",
       "state" : {
         "branch" : "main",
-        "revision" : "98dfe1bb7770264f538f836c1b87801bbf492fb7"
+        "revision" : "4eb67d3d277996f48d0c557aeec21989da29d43a"
       }
     }
   ],


### PR DESCRIPTION
Added an argument to `scanForAccessibility()` which accepts the scan name so we can produce a properly named report in the HTML output.