### PR TITLE
chore: Update Github Actions to Use Commit SHA.

### DIFF
--- a/.github/workflows/scanAndReport.yml
+++ b/.github/workflows/scanAndReport.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: macos-latest # Make sure xcodebuild simulator/OS is supported: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
     steps:    
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1
         with:
           xcode-version: '15.4'
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3
       - name: Install the Reporter CLI
         env:
           apiKey: ${{ secrets.AGORA_API_KEY_KA }}
@@ -43,7 +43,7 @@ jobs:
           /Users/runner/reporter ${scanFolderPath} "AxeReport" --format=html
       - name: Upload a Build Artifact
         if: always()
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: axeDevTools Report
           path: AxeReport # or path/to/artifact

--- a/.github/workflows/semantic_pr_title.yml
+++ b/.github/workflows/semantic_pr_title.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         env:
           TITLE: ${{ github.event.pull_request.title }}
         with:


### PR DESCRIPTION
related to [#2046](https://app.zenhub.com/workspaces/mobile---ios-618c5382fb76f00010561506/issues/gh/dequelabs/attestios/2046)

## Summary
Updates all github actions to use commit SHA instead of a version tag for better security practices.

**Does this change effect a customer's experience or result?**
No.

**What was the behavior?**
3rd party actions were referenced by their version tag.

**What is the behavior now?**
3rd party actions will be referenced by a commit SHA.