### PR TITLE
chore: Upgrade to 2.15.0

### DIFF
--- a/axe-devtools-ios-sample-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/axe-devtools-ios-sample-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/dequelabs/axe-devtools-ios",
       "state" : {
         "branch" : "main",
-        "revision" : "1adfee284c04ebe9219db8a21c2ac56178223bcd"
+        "revision" : "d96d44fd30aa0d23c0f2056adaf1eeb6d07aa09b"
       }
     }
   ],


### PR DESCRIPTION
Upgrade to use version [2.15.0](https://github.com/dequelabs/axe-devtools-ios/releases/tag/2.15.0) of the framework