### PR TITLE
feat: Sauce Labs script for virtual devices.

### DIFF
--- a/.sauce/configReal.yml
+++ b/.sauce/configReal.yml
@@ -12,4 +12,4 @@ suites:
   - name: "RegressionUITests"
     devices:
       - name: "iPhone.*"
-        platformVersion: "17.2"
+        platformVersion: "17.5.1"

--- a/.sauce/configVirtual.yml
+++ b/.sauce/configVirtual.yml
@@ -1,0 +1,16 @@
+apiVersion: v1alpha
+kind: xcuitest
+sauce:
+  region: us-west-1
+  concurrency: 1
+
+xcuitest:
+  app: "axe-devtools-ios-sample-app.zip"
+  testApp: "RegressionUITests-Runner.zip"
+
+suites:
+  - name: "RegressionUITests"
+    simulators:
+      - name: "iPhone 12 Simulator"
+        platformVersions:
+          - "17.0"

--- a/README.md
+++ b/README.md
@@ -24,18 +24,20 @@ This project uses Swift Package Manager to pull in the frameworks from [axe-devt
 
 <img src="doc_img/UITests.png" alt="Shows the click area for running the UI test."/>
 
-### For Automated Testing with Sauce Labs (Real Device Only)
-
-_Note: XCUITests are only supported with a real device from Sauce at this time. This project requires a device on iOS 16.0 or later._
+### For Automated Testing with Sauce Labs
+_Note: This project requires a device on iOS 16.0 or later. Additionally, Virtual Devices running iOS 17.0 may experience hanging during testing. Use an iOS 16.2 Virtual Device to see a successful test run._
 
 To run a test with this project, or to setup your own project, follow our online guide to get started with [XCUITesting on SauceLabs.](https://docs.deque.com/devtools-mobile/ios-example-sauce-labs-xcui)
 
 Assuming you have already downloaded the sample project to your computer:
 1. Add your Deque API Key to `Login.swift`.
 2. Open a Terminal window, enter `cd `, then drag and drop the `axe-devtools-ios-sample-app` from Finder into the Terminal window. Hit return/enter.
-3. In the same window, type `sh prepareForSauce.sh`. Hit return/enter.
 
-This script will build the app, and begin executing automated tests in your Sauce Labs environment.
+To run on **Real Devices**, type `sh prepareForSauceReal.sh` in the same window. Hit return/enter.
+
+To run on **Virtual Devices**, type `sh prepareForSauceVirtual.sh` in the same window. Hit return/enter.
+
+These scripts will build the app for the appropriate device type and begin executing automated tests in your Sauce Labs environment.
 
 ## Have a Question? Found a bug?
 

--- a/prepareForSauceReal.sh
+++ b/prepareForSauceReal.sh
@@ -20,7 +20,7 @@ rm -rf Payload/*
 mv $APP_LOCATION/RegressionUITests-Runner.app Payload
 zip -r -qq "RegressionUITests-Runner.ipa" Payload
 
-saucectl run
+saucectl run -c ./.sauce/configReal.yml
 
 rm -rf Payload
 rm -rf DerivedData

--- a/prepareForSauceVirtual.sh
+++ b/prepareForSauceVirtual.sh
@@ -1,0 +1,24 @@
+APP_LOCATION="DerivedData/Build/Products/Debug-iphonesimulator"
+APP_NAME="axe-devtools-ios-sample-app"
+
+rm -rf *.zip
+
+xcodebuild build-for-testing -configuration Debug \
+  -scheme "axe-devtools-ios-sample-app" \
+  -target "RegressionUITests" \
+  -sdk iphonesimulator \
+  -derivedDataPath "./DerivedData" \
+  -quiet \
+  EXCLUDED_ARCHS="" \
+  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+mkdir Temp
+
+mv $APP_LOCATION/$APP_NAME.app $APP_LOCATION/RegressionUITests-Runner.app temp
+zip -r -qq axe-devtools-ios-sample-app.zip Temp/axe-devtools-ios-sample-app.app
+zip -r -qq RegressionUITests-Runner.zip Temp/RegressionUITests-Runner.app
+
+saucectl run -c ./.sauce/configVirtual.yml
+
+rm -rf Temp
+rm -rf DerivedData


### PR DESCRIPTION
Related to [#1349](https://app.zenhub.com/workspaces/mobile---ios-618c5382fb76f00010561506/issues/gh/dequelabs/attestios/1349)

Adding in an example script to show how to run automated tests with Sauce Labs on Virtual Devices. An example previously only existed for running on Real Devices, but Sauce Labs now supports Virtual Devices as well.

- New script `prepareForSauceVirtual.sh` that runs the RegressionUI tests on Sauce Labs Virtual Devices 
- New config file `configVirtual.yml` to be used with the new script
- `prepareForSauce.sh` renamed to `prepareForSauceReal.sh` to distinguish between the two examples 
- README updated with instructions on how to run both scripts and what they accomplish